### PR TITLE
Remove the reference to the interruptible system call check.

### DIFF
--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -6,8 +6,7 @@ from pocketlint import PocketLintConfig, PocketLinter
 class TranslationCanaryLintConfig(PocketLintConfig):
     @property
     def disabledOptions(self):
-        return [ "W9930",           # Found interruptible system call %s
-                 "I0011",           # Locally disabling %s
+        return [ "I0011",           # Locally disabling %s
                ]
 
     @property


### PR DESCRIPTION
This is not a thing anymore.

https://github.com/rhinstaller/pocketlint/pull/12
